### PR TITLE
部分期货服务商CTP实盘登录时要求填写UserProductInfo的问题

### DIFF
--- a/C-CTP/src/QuantBox.C2CTP/QuantBox.C2CTP.cpp
+++ b/C-CTP/src/QuantBox.C2CTP/QuantBox.C2CTP.cpp
@@ -403,7 +403,7 @@ QUANTBOXC2CTP_API void __stdcall TD_Connect(
 		if(szUserProductInfo&&szAuthCode)
 			TD_GetApi(pTraderApi)->Connect(szPath,szAddresses,szBrokerId,szInvestorId,szPassword,nResumeType,szUserProductInfo,szAuthCode);
 		else
-			TD_GetApi(pTraderApi)->Connect(szPath,szAddresses,szBrokerId,szInvestorId,szPassword,nResumeType,"","");
+			TD_GetApi(pTraderApi)->Connect(szPath,szAddresses,szBrokerId,szInvestorId,szPassword,nResumeType,szUserProductInfo,"");
 	}
 }
 


### PR DESCRIPTION
部分期货服务商CTP实盘要求UserProductInfo必须填写
